### PR TITLE
Change Style/FlipFlop to Lint/FlipFlop

### DIFF
--- a/config/rubocop.rails.yml
+++ b/config/rubocop.rails.yml
@@ -742,7 +742,7 @@ Style/EvenOdd:
 Layout/InitialIndentation:
   Enabled: true
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Enabled: true
 
 Style/IfInsideElse:


### PR DESCRIPTION
Made a slight fix to rubocop.rails.yml to fix the Style/FlipFlop error by changing the line to Lint/Flipflop

![image](https://user-images.githubusercontent.com/2214495/53916616-65ed8080-4017-11e9-86c0-d1fe63aec76a.png)